### PR TITLE
security fix(workflow): prevent shell injection from arbitrary input

### DIFF
--- a/packages/pnpm/action.yaml
+++ b/packages/pnpm/action.yaml
@@ -40,9 +40,11 @@ runs:
       if: "${{ inputs.using_nextjs == 'true' }}"
       shell: bash
       id: path
+      env:
+        INPUT_DIRECTORY: ${{ inputs.working_directory }}
       run: |-
         prefix="."
-        string=${{ inputs.working_directory }}
+        string=$INPUT_DIRECTORY
         cache_path=${string#"$prefix"}
         echo "::set-output name=cache-path::${{ github.workspace }}$cache_path/.next/cache"
 

--- a/packages/yarn/action.yaml
+++ b/packages/yarn/action.yaml
@@ -38,9 +38,11 @@ runs:
       if: "${{ inputs.using_nextjs == 'true' }}"
       shell: bash
       id: path
+      env:
+        INPUT_DIRECTORY: ${{ inputs.working_directory }}
       run: |-
         prefix="."
-        string=${{ inputs.working_directory }}
+        string=$INPUT_DIRECTORY
         cache_path=${string#"$prefix"}
         echo "::set-output name=cache-path::${{ github.workspace }}$cache_path/.next/cache"
 


### PR DESCRIPTION
### Description

The GitHub workflow is vulnerable to unauthorized modification of the base repository or secrets exfiltration from a workflow dispatch event via arbitrary input. 

### Impact

This vulnerability allows for arbitrary command injection into the bash script that may allow exfiltration of the secret tokens to the attacker controlled server. For proof of a concept an input with the following value `test; touch pwned #` would create **pwned** file.