### PR TITLE
feat(backend): added build & deploy composite

### DIFF
--- a/build/backend/action.yaml
+++ b/build/backend/action.yaml
@@ -1,0 +1,95 @@
+name: "CI Build"
+description: "Build and push docker image"
+
+inputs:
+  env:
+    required: false
+    description: "environment to deploy to"
+    default: "dev"
+
+  gh-user:
+    required: true
+    description: "gh user"
+
+  gh-token:
+    required: true
+    description: "gh token"
+
+  cache:
+    required: false
+    description: "enable cache for go modules"
+    default: "true"
+
+  cache-dependency-path:
+    required: false
+    description: "go sum location"
+    default: "go.sum"
+
+  go-version:
+    required: false
+    description: "go version"
+    default: "^1.13.1"
+
+  build-push-image:
+    required: false
+    description: "build and push image for deployment"
+    default: "false"
+
+  credentials_json:
+    required: true
+    description: "GCP credentials services account"
+
+  project_id:
+    required: true
+    description: "GCP project id"
+
+  gcr_host:
+    required: true
+    description: "GCP container registry host"
+
+
+runs:
+  using: "composite"
+  steps:
+    - name: Checking out repository
+      uses: actions/checkout@v2
+
+    - name: Configure Git for private modules
+      env:
+        USER: ${{ inputs.gh-user }}
+        TOKEN: ${{ inputs.gh-token }}
+      shell: bash
+      run: git config --global url."https://${USER}:${TOKEN}@github.com".insteadOf "https://github.com"
+
+    - uses: actions/setup-go@v3
+      with:
+        cache: ${{ inputs.cache }}
+        cache-dependency-path: ${{ inputs.cache-dependency-path }}
+        go-version: ${{ inputs.go-version }} # The Go version to download (if necessary) and use.
+
+    - name: Setup gcloud
+      if: "${{ inputs.build-push-image == 'true' }}"
+      uses: kitabisa/composite-actions/packages/gcloud@main
+      with:
+        project_id: ${{ inputs.project_id }}
+        credentials_json: ${{ inputs.credentials_json }}
+
+    - name: Setup docker buildx
+      if: "${{ inputs.build-push-image == 'true' }}"
+      uses: kitabisa/composite-actions/packages/buildx@main
+      with:
+        project_id: ${{ inputs.project_id }}
+        gcr_host: ${{ inputs.gcr_host }}
+
+    - name: Build application
+      shell: bash
+      run: |-
+        make build
+
+    - name: Build, tag, and push Docker image
+      shell: bash
+      if: "${{ inputs.build-push-image == 'true' }}"
+      env:
+        DOCKER_REPOSITORY: ${{ inputs.gcr_host }}/${{ inputs.project_id }}
+      run: |-
+        make package

--- a/deploy/backend/action.yaml
+++ b/deploy/backend/action.yaml
@@ -1,0 +1,77 @@
+name: "CI Build"
+description: "Build and push docker image"
+
+inputs:
+  project_id:
+    required: true
+    description: "GCP project id"
+
+  gcr_host:
+    required: true
+    description: "GCP container registry host"
+
+  chartmuseum_host:
+    required: true
+    description: "ChartMuseum host"
+
+  chartmuseum_user:
+    required: true
+    description: "ChartMuseum user"
+
+  chartmuseum_pass:
+    required: true
+    description: "ChartMuseum password"
+
+  gke_cluster_name:
+    required: true
+    description: "GKE cluster name"
+
+  gke_cluster_zone:
+    required: true
+    description: "GKE cluster location zone"
+
+  rancher_host:
+    required: true
+    description: "Rancher host"
+
+  rancher_access_key:
+    required: true
+    description: "Rancher access key"
+
+  rancher_secret_key:
+    required: true
+    description: "Rancher secret key"
+
+  rancher_cluster_id:
+    required: true
+    description: "Rancher cluster id"
+
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup gke credential
+      uses: kitabisa/composite-actions/packages/gke-credential@main
+      with:
+        gke_cluster_name: ${{ inputs.gke_cluster_name }}
+        gke_cluster_zone: ${{ inputs.gke_cluster_zone }}
+        project_id: ${{ inputs.project_id }}
+
+    - name: Deploy
+      uses: kitabisa/composite-actions/packages/makefile@main
+      with:
+        project_id: ${{ inputs.project_id }}
+        gcr_host: ${{ inputs.gcr_host }}
+        chartmuseum_host: ${{ inputs.chartmuseum_host }}
+        chartmuseum_user: ${{ inputs.chartmuseum_user }}
+        chartmuseum_pass: ${{ inputs.chartmuseum_pass }}
+        deploy: true
+
+    - name: Rancher ns mover
+      uses: kitabisa/composite-actions/packages/rancher@main
+      with:
+        working_directory: ${{ inputs.working_directory }}
+        rancher_host: ${{ inputs.rancher_host }}
+        rancher_access_key: ${{ inputs.rancher_access_key }}
+        rancher_secret_key: ${{ inputs.rancher_secret_key }}
+        rancher_cluster_id: ${{ inputs.rancher_cluster_id }}


### PR DESCRIPTION
Tested in suramadu
https://github.com/kitabisa/suramadu/actions/runs/3755325002

Please review and approve so we can use main branch for build push deploy dev/stg/prod

The approach is created to standardize workflow that utilize
- build
- deploy

Some assumptions
- Build can be used by build test workflow
- Build test doesn't need to push docker image
- Every build won't be pushed to GCR unless we want to deploy
- Only in deploy action we include GCR & gCloud setup
- For golang, action/go@v3 already provide caching capability so we don't need action/cache

```
    - uses: actions/setup-go@v3
      with:
        cache: ${{ inputs.cache }}
        cache-dependency-path: ${{ inputs.cache-dependency-path }}
        go-version: ${{ inputs.go-version }} # The Go version to download (if necessary) and use.
```

