### PR TITLE
feat: updated non required value and added gh token on make build

### DIFF
--- a/build/backend/action.yaml
+++ b/build/backend/action.yaml
@@ -36,15 +36,15 @@ inputs:
     default: "false"
 
   credentials_json:
-    required: true
+    required: false
     description: "GCP credentials services account"
 
   project_id:
-    required: true
+    required: false
     description: "GCP project id"
 
   gcr_host:
-    required: true
+    required: false
     description: "GCP container registry host"
 
 
@@ -83,6 +83,8 @@ runs:
 
     - name: Build application
       shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.gh-token }}
       run: |-
         make build
 


### PR DESCRIPTION
3 value ini ga mandatory karena defaultnya build push image false
```
credentials_json
project_id
gcr_host
```

jadi hanya perlu ditambahin kalo build push imagenya `true` aja 

Terus ketika make build ada error karena token githubnya ga ada jadi ga bisa nge-fetch dependency repo private
makanya ditambahin env github token ketika make build