### PR TITLE
feat: added swagger & mockoon build

### DIFF
--- a/build/backend/action.yaml
+++ b/build/backend/action.yaml
@@ -118,7 +118,7 @@ runs:
 
     - name: Build, tag, and push Docker image Swagger
       if: "${{ inputs.build_push_image_swagger == 'true' }}"
-      uses: kitabisa/composite-actions/packages/swagger@2e5f2f8a0c44e82a72adf2aff32ae0f4ac2abf91
+      uses: kitabisa/composite-actions/packages/swagger@main
       with:
         project_id: ${{ inputs.project_id }}
         gcr_host: ${{ inputs.gcr_host }}

--- a/build/backend/action.yaml
+++ b/build/backend/action.yaml
@@ -10,7 +10,7 @@ inputs:
     required: true
     description: "gh token"
 
-  cache-dependency-path:
+  cache_dependency_path:
     required: false
     description: "go sum location"
     default: "go.sum"
@@ -89,8 +89,8 @@ runs:
 
     - uses: actions/setup-go@v4
       with:
-        cache-dependency-path: ${{ inputs.cache-dependency-path }}
-        go-version: ${{ inputs.go-version }} # The Go version to download (if necessary) and use.
+        cache-dependency-path: ${{ inputs.cache_dependency_path }}
+        go-version: ${{ inputs.go_version }} # The Go version to download (if necessary) and use.
 
     - name: Setup gcloud
       if: "${{ inputs.build_push_image == 'true' }}"

--- a/build/backend/action.yaml
+++ b/build/backend/action.yaml
@@ -118,8 +118,9 @@ runs:
 
     - name: Build, tag, and push Docker image Swagger
       if: "${{ inputs.build_push_image_swagger == 'true' }}"
-      uses: kitabisa/composite-actions/packages/swagger@6ee6a3445675361980c764d6e0266752dd156ada
+      uses: kitabisa/composite-actions/packages/swagger@fdcdd1ba2e421a045f2c624c9570d23e79b7e517
       with:
+        working_directory: ${{ inputs.working_directory }}
         project_id: ${{ inputs.project_id }}
         gcr_host: ${{ inputs.gcr_host }}
         openapi_input_file: ${{ inputs.openapi_input_file }}

--- a/build/backend/action.yaml
+++ b/build/backend/action.yaml
@@ -118,9 +118,8 @@ runs:
 
     - name: Build, tag, and push Docker image Swagger
       if: "${{ inputs.build_push_image_swagger == 'true' }}"
-      uses: kitabisa/composite-actions/packages/swagger@fdcdd1ba2e421a045f2c624c9570d23e79b7e517
+      uses: kitabisa/composite-actions/packages/swagger@2e5f2f8a0c44e82a72adf2aff32ae0f4ac2abf91
       with:
-        working_directory: ${{ inputs.working_directory }}
         project_id: ${{ inputs.project_id }}
         gcr_host: ${{ inputs.gcr_host }}
         openapi_input_file: ${{ inputs.openapi_input_file }}

--- a/build/backend/action.yaml
+++ b/build/backend/action.yaml
@@ -2,11 +2,11 @@ name: "CI Build"
 description: "Build and push docker image"
 
 inputs:
-  gh-user:
+  gh_user:
     required: true
     description: "gh user"
 
-  gh-token:
+  gh_token:
     required: true
     description: "gh token"
 
@@ -15,15 +15,30 @@ inputs:
     description: "go sum location"
     default: "go.sum"
 
-  go-version:
+  go_version:
     required: false
     description: "go version"
     default: "^1.13.1"
 
-  build-push-image:
+  build:
+    required: false
+    description: "Run make build"
+    default: true
+    type: boolean
+
+  build_push_image:
     required: false
     description: "build and push image for deployment"
     default: "false"
+
+  build_push_image_swagger:
+    required: false
+    description: "build and push image for swagger"
+    default: "false"
+
+  build_push_image_mockoon:
+    required: false
+    description: "build and push image for mockoon"
 
   credentials_json:
     required: false
@@ -37,17 +52,38 @@ inputs:
     required: false
     description: "GCP container registry host"
 
+  swagger_script_path:
+    required: false
+    description: "swagger script path"
+
+  openapi_input_file:
+    required: false
+    description: "openapi input file"
+
+  openapi_output_file:
+    required: false
+    description: "openapi output file"
+
+  working_directory:
+    required: false
+    description: "Set working directory"
+    default: "."
+    type: string
+
 
 runs:
   using: "composite"
   steps:
     - name: Checking out repository
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        token: ${{ inputs.gh_token }}
 
     - name: Configure Git for private modules
       env:
-        USER: ${{ inputs.gh-user }}
-        TOKEN: ${{ inputs.gh-token }}
+        USER: ${{ inputs.gh_user }}
+        TOKEN: ${{ inputs.gh_token }}
       shell: bash
       run: git config --global url."https://${USER}:${TOKEN}@github.com".insteadOf "https://github.com"
 
@@ -57,30 +93,44 @@ runs:
         go-version: ${{ inputs.go-version }} # The Go version to download (if necessary) and use.
 
     - name: Setup gcloud
-      if: "${{ inputs.build-push-image == 'true' }}"
+      if: "${{ inputs.build_push_image == 'true' }}"
       uses: kitabisa/composite-actions/packages/gcloud@main
       with:
         project_id: ${{ inputs.project_id }}
         credentials_json: ${{ inputs.credentials_json }}
 
     - name: Setup docker buildx
-      if: "${{ inputs.build-push-image == 'true' }}"
+      if: "${{ inputs.build_push_image == 'true' }}"
       uses: kitabisa/composite-actions/packages/buildx@main
       with:
         project_id: ${{ inputs.project_id }}
         gcr_host: ${{ inputs.gcr_host }}
 
     - name: Build application
-      shell: bash
-      env:
-        GITHUB_TOKEN: ${{ inputs.gh-token }}
-      run: |-
-        make build
+      id: build-app
+      uses: kitabisa/composite-actions/packages/makefile@main
+      with:
+        build: ${{ inputs.build }}
+        working_directory: ${{ inputs.working_directory }}
+        project_id: ${{ inputs.project_id }}
+        gcr_host: ${{ inputs.gcr_host }}
+        package: ${{ inputs.build_push_image }}
 
-    - name: Build, tag, and push Docker image
+    - name: Build, tag, and push Docker image Swagger
+      if: "${{ inputs.build_push_image_swagger == 'true' }}"
+      uses: kitabisa/composite-actions/packages/swagger@65557f7840e6066ab3be3f49d862f51928a3d4b1
+      with:
+        project_id: ${{ inputs.project_id }}
+        gcr_host: ${{ inputs.gcr_host }}
+        openapi_input_file: ${{ inputs.openapi_input_file }}
+        openapi_output_file: ${{ inputs.openapi_output_file }}
+        swagger_script_path: ${{ inputs.swagger_script_path }}
+
+    # if you require to build mockoon image for 3rd party mocking
+    - name: Build, tag, and push Docker image Mockoon
       shell: bash
-      if: "${{ inputs.build-push-image == 'true' }}"
+      if: "${{ inputs.build_push_image_mockoon == 'true' }}"
       env:
         DOCKER_REPOSITORY: ${{ inputs.gcr_host }}/${{ inputs.project_id }}
       run: |-
-        make package
+        make package-mockoon

--- a/build/backend/action.yaml
+++ b/build/backend/action.yaml
@@ -118,7 +118,7 @@ runs:
 
     - name: Build, tag, and push Docker image Swagger
       if: "${{ inputs.build_push_image_swagger == 'true' }}"
-      uses: kitabisa/composite-actions/packages/swagger@65557f7840e6066ab3be3f49d862f51928a3d4b1
+      uses: kitabisa/composite-actions/packages/swagger@6ee6a3445675361980c764d6e0266752dd156ada
       with:
         project_id: ${{ inputs.project_id }}
         gcr_host: ${{ inputs.gcr_host }}

--- a/deploy/backend/action.yaml
+++ b/deploy/backend/action.yaml
@@ -85,7 +85,7 @@ runs:
         project_id: ${{ inputs.project_id }}
 
     - name: Deploy
-      uses: kitabisa/composite-actions/packages/makefile@6ee6a3445675361980c764d6e0266752dd156ada
+      uses: kitabisa/composite-actions/packages/makefile@main
       with:
         working_directory: ${{ inputs.working_directory }}
         project_id: ${{ inputs.project_id }}

--- a/deploy/backend/action.yaml
+++ b/deploy/backend/action.yaml
@@ -61,6 +61,12 @@ inputs:
     default: "."
     type: string
 
+  setup_helmfiles:
+    required: false
+    description: "Setup helmfiles"
+    default: false
+    type: boolean
+
 runs:
   using: "composite"
   steps:
@@ -88,7 +94,7 @@ runs:
         chartmuseum_user: ${{ inputs.chartmuseum_user }}
         chartmuseum_pass: ${{ inputs.chartmuseum_pass }}
         deploy: true
-        setup_helmfiles: false
+        setup_helmfiles: ${{ inputs.setup_helmfiles }}
 
     - name: Rancher ns mover
       uses: kitabisa/composite-actions/packages/rancher@main

--- a/deploy/backend/action.yaml
+++ b/deploy/backend/action.yaml
@@ -7,7 +7,7 @@ inputs:
     description: "environment to deploy to"
     default: "dev"
 
-  gh-token:
+  gh_token:
     required: true
     description: "gh token"
 
@@ -55,17 +55,21 @@ inputs:
     required: true
     description: "Rancher cluster id"
 
+  working_directory:
+    required: false
+    description: "Set working directory"
+    default: "."
+    type: string
 
 runs:
   using: "composite"
   steps:
-    - name: Create prod deployment
+    - name: Create env deployment
       uses: chrnorm/deployment-action@v2
       id: deployment
       with:
-        token: ${{ inputs.gh-token }}
+        token: ${{ inputs.gh_token }}
         environment: ${{ inputs.env }}
-
 
     - name: Setup gke credential
       uses: kitabisa/composite-actions/packages/gke-credential@main
@@ -75,14 +79,16 @@ runs:
         project_id: ${{ inputs.project_id }}
 
     - name: Deploy
-      uses: kitabisa/composite-actions/packages/makefile@main
+      uses: kitabisa/composite-actions/packages/makefile@91bf3826bd5cbcd7ef1b7b83021068f2193432b2
       with:
+        working_directory: ${{ inputs.working_directory }}
         project_id: ${{ inputs.project_id }}
         gcr_host: ${{ inputs.gcr_host }}
         chartmuseum_host: ${{ inputs.chartmuseum_host }}
         chartmuseum_user: ${{ inputs.chartmuseum_user }}
         chartmuseum_pass: ${{ inputs.chartmuseum_pass }}
         deploy: true
+        setup_helmfiles: false
 
     - name: Rancher ns mover
       uses: kitabisa/composite-actions/packages/rancher@main
@@ -95,16 +101,16 @@ runs:
 
     - uses: chrnorm/deployment-status@v2
       if: success()
-      name: Set prod-test deployment success
+      name: Set env deployment success
       with:
-        token: ${{ inputs.gh-token }}
+        token: ${{ inputs.gh_token }}
         state: "success"
         deployment-id: ${{ steps.deployment.outputs.deployment_id }}
 
     - uses: chrnorm/deployment-status@v2
       if: failure()
-      name: Set prod-test deployment failure
+      name: Set env deployment failure
       with:
-        token: ${{ inputs.gh-token }}
+        token: ${{ inputs.gh_token }}
         state: "failure"
         deployment-id: ${{ steps.deployment.outputs.deployment_id }}

--- a/deploy/backend/action.yaml
+++ b/deploy/backend/action.yaml
@@ -85,7 +85,7 @@ runs:
         project_id: ${{ inputs.project_id }}
 
     - name: Deploy
-      uses: kitabisa/composite-actions/packages/makefile@91bf3826bd5cbcd7ef1b7b83021068f2193432b2
+      uses: kitabisa/composite-actions/packages/makefile@6ee6a3445675361980c764d6e0266752dd156ada
       with:
         working_directory: ${{ inputs.working_directory }}
         project_id: ${{ inputs.project_id }}

--- a/packages/makefile/action.yaml
+++ b/packages/makefile/action.yaml
@@ -109,6 +109,13 @@ inputs:
     default: "2"
     type: string
 
+  setup_helmfiles:
+    required: false
+    description: "Setup helmfiles"
+    default: true
+    type: boolean
+
+
 outputs:
   build-time:
     description: "Define build time"
@@ -134,6 +141,7 @@ runs:
       uses: azure/setup-helm@v3
 
     - name: Setup Helmfile
+      if: "${{ inputs.setup_helmfiles == 'true' }}"
       uses: kitabisa/actions/setup-helmfile@master
 
     - name: Install dependencies

--- a/packages/swagger/action.yaml
+++ b/packages/swagger/action.yaml
@@ -1,0 +1,55 @@
+name: "Setup Swagger Build"
+description: "Setup Swagger build"
+
+inputs:
+  swagger_script_path:
+    required: false
+    description: "shell script path and name for swagger env"
+
+  project_id:
+    required: false
+    description: "GCP project id"
+
+  gcr_host:
+    required: false
+    description: "GCP container registry host"
+
+  openapi_input_file:
+    required: false
+    description: "openapi input file"
+
+  openapi_output_file:
+    required: false
+    description: "openapi output file"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Replace env swagger
+      shell: bash
+      run: |-
+        cd ${{ inputs.swagger_script_path }}
+        sh swagger_env.sh
+
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 16
+
+    # then use redoc-cli-github-action to generate your HTML bundle
+    - name: install redoc
+      shell: bash
+      run: |-
+        npm i -g @redocly/cli@latest
+
+    - name: bundle openapi
+      shell: bash
+      run: |-
+        openapi bundle ${{ inputs.openapi_input_file }} -o ${{ inputs.openapi_output_file }}
+        cat ${{ inputs.openapi_output_file }}
+
+    - name: Build, tag, and push Docker image Swagger
+      shell: bash
+      env:
+        DOCKER_REPOSITORY: ${{ inputs.gcr_host }}/${{ inputs.project_id }}
+      run: |-
+        make package-swagger

--- a/packages/swagger/action.yaml
+++ b/packages/swagger/action.yaml
@@ -22,18 +22,11 @@ inputs:
     required: false
     description: "openapi output file"
 
-  working_directory:
-    required: false
-    description: "Set working directory"
-    default: "."
-    type: string
-
 runs:
   using: "composite"
   steps:
     - name: Replace env swagger
       shell: bash
-      working-directory: ${{ inputs.working_directory }}
       run: |-
         cd ${{ inputs.swagger_script_path }}
         sh swagger_env.sh
@@ -50,14 +43,12 @@ runs:
 
     - name: bundle openapi
       shell: bash
-      working-directory: ${{ inputs.working_directory }}
       run: |-
         openapi bundle ${{ inputs.openapi_input_file }} -o ${{ inputs.openapi_output_file }}
         cat ${{ inputs.openapi_output_file }}
 
     - name: Build, tag, and push Docker image Swagger
       shell: bash
-      working-directory: ${{ inputs.working_directory }}
       env:
         DOCKER_REPOSITORY: ${{ inputs.gcr_host }}/${{ inputs.project_id }}
       run: |-

--- a/packages/swagger/action.yaml
+++ b/packages/swagger/action.yaml
@@ -22,11 +22,18 @@ inputs:
     required: false
     description: "openapi output file"
 
+  working_directory:
+    required: false
+    description: "Set working directory"
+    default: "."
+    type: string
+
 runs:
   using: "composite"
   steps:
     - name: Replace env swagger
       shell: bash
+      working-directory: ${{ inputs.working_directory }}
       run: |-
         cd ${{ inputs.swagger_script_path }}
         sh swagger_env.sh
@@ -43,12 +50,14 @@ runs:
 
     - name: bundle openapi
       shell: bash
+      working-directory: ${{ inputs.working_directory }}
       run: |-
         openapi bundle ${{ inputs.openapi_input_file }} -o ${{ inputs.openapi_output_file }}
         cat ${{ inputs.openapi_output_file }}
 
     - name: Build, tag, and push Docker image Swagger
       shell: bash
+      working-directory: ${{ inputs.working_directory }}
       env:
         DOCKER_REPOSITORY: ${{ inputs.gcr_host }}/${{ inputs.project_id }}
       run: |-


### PR DESCRIPTION
- added swagger build for repo that wants to use swagger
- added mockoon for mocking so we can put mocking in front of specific service by having its own pod instead relying on sachie. Great for dev so we can store mocking in each repo instead of making it in sachie
- added work dir setting during build/deploy to support monorepo in backend