### PR TITLE
backend: separate build & deploy phase

### DIFF
--- a/deploy/backend/action.yaml
+++ b/deploy/backend/action.yaml
@@ -67,6 +67,11 @@ inputs:
     default: false
     type: boolean
 
+  credentials_json:
+    required: true
+    description: "GCP credentials services account"
+    type: string
+
 runs:
   using: "composite"
   steps:
@@ -76,6 +81,12 @@ runs:
       with:
         token: ${{ inputs.gh_token }}
         environment: ${{ inputs.env }}
+
+    - name: Setup gcloud
+      uses: kitabisa/composite-actions/packages/gcloud@main
+      with:
+        project_id: ${{ inputs.project_id }}
+        credentials_json: ${{ inputs.credentials_json }}
 
     - name: Setup gke credential
       uses: kitabisa/composite-actions/packages/gke-credential@main

--- a/deploy/backend/action.yaml
+++ b/deploy/backend/action.yaml
@@ -82,6 +82,9 @@ runs:
         token: ${{ inputs.gh_token }}
         environment: ${{ inputs.env }}
 
+    - name: Checking out repository
+      uses: actions/checkout@v3
+      
     - name: Setup gcloud
       uses: kitabisa/composite-actions/packages/gcloud@main
       with:


### PR DESCRIPTION
we wanted to separate build and deploy phase so when ci failure during deploy, we just restart the deploy phase without rebuilding the whole thing again