### PR TITLE
fix: setup helmfiles

### DIFF
--- a/packages/makefile/action.yaml
+++ b/packages/makefile/action.yaml
@@ -112,8 +112,8 @@ inputs:
   setup_helmfiles:
     required: false
     description: "Setup helmfiles"
-    default: true
-    type: boolean
+    default: "true"
+    type: string
 
 
 outputs:


### PR DESCRIPTION
currently setup helmfiles default value is not working. Even though we setup the value to be true, it is always set to be false. Turns out the boolean value doesn't work so we have to set it as string. 

Default is true
![Screenshot 2023-10-16 at 16 05 07](https://github.com/kitabisa/composite-actions/assets/11158339/c7d84438-72ab-4cc4-81c0-77df51fb8821)

No value needed to be set from CI 
![Screenshot 2023-10-16 at 16 05 13](https://github.com/kitabisa/composite-actions/assets/11158339/22588314-13f5-462e-95b8-f4c36e1f542e)
