### PR TITLE
fix: generate coverage path

### DIFF
--- a/coverage/backend/action.yaml
+++ b/coverage/backend/action.yaml
@@ -64,7 +64,7 @@ runs:
 
     - uses: actions/setup-go@v4
       with:
-        cache-dependency-path: ./${{ inputs.working_directory }}/${{ inputs.cache_dependency_path }}
+        cache-dependency-path: ${{ inputs.working_directory }}/${{ inputs.cache_dependency_path }}
         go-version: ${{ inputs.go_version }} # The Go version to download (if necessary) and use.
 
     - name: Generate Master Coverage


### PR DESCRIPTION
need to remove relative path because coverage composite can be used in monorepo such as santet-v2 and currently it doesn't work. Removing this relative path result success

https://github.com/kitabisa/santet-v2/actions/runs/6603495780/job/17936717588