### PR TITLE
ci: add input target repo for trigger automation when deploy

### DIFF
--- a/sdet/trigger-automation-test-when-deploy/action.yaml
+++ b/sdet/trigger-automation-test-when-deploy/action.yaml
@@ -37,6 +37,12 @@ inputs:
     description: "trigger automation test api when deploy"
     default: "false"
     type: string
+  
+  target_repo:
+    description: "target repository to trigger (e.g., qorin)"
+    required: false
+    default: "qorin"
+    type: string
 
   pr_author:
     required: false
@@ -90,7 +96,7 @@ runs:
       shell: bash
       if: "${{ inputs.trigger_automation_test_api_when_deploy == 'true' && env.PR_AUTHOR != 'kitabisaengineer' }}"
       run: |
-        if gh api repos/kitabisa/qorin/git/refs/heads/${PR_BRANCH} > /dev/null 2>&1; then
+        if gh api repos/kitabisa/${{ inputs.target_repo }}/git/refs/heads/${PR_BRANCH} > /dev/null 2>&1; then
           TARGET_REF=${PR_BRANCH}
         else
           echo "branch ${PR_BRANCH} not found. Using fallback 'master'"
@@ -99,7 +105,7 @@ runs:
 
         echo "using ref: $TARGET_REF"
 
-        gh workflow run -R kitabisa/qorin .github/workflows/trigger-when-deploy.yaml \
+        gh workflow run -R kitabisa/${{ inputs.target_repo }} .github/workflows/trigger-when-deploy.yaml \
           -f profile=${{ inputs.service_name }} \
           -f pr_author="${PR_AUTHOR}" \
           -f pr_link="${PR_LINK}" \


### PR DESCRIPTION
## What does this PR do?
_Place what this pull request changes and anything affected. If your PR block or require another PR, also need to mention here_
- add add input `target_repo` for trigger automation when deploy with default value is `qorin`. this input to provide run from another target repository like `flash`

## Why are we doing this? Any context or related work?
_You may put your link or another here_

## Where should a reviewer start?
_optional -- if your changes affected so much files, it is encouraged to give helper for reviewer_

## Screenshots
_optional -- You may put the database, sequence or any diagram needed_

## Manual testing steps?
_Steps to do tests. including all possible that can hape_

## Config changes
_optional -- If there's config changes, put it here_

## Deployment instructions
_optional -- Better to put it if there's some 'special case' for deployment_
