### PR TITLE
feat: add optional step for upload download static build from github artifact

### DIFF
--- a/frontend/build/action.yaml
+++ b/frontend/build/action.yaml
@@ -102,6 +102,18 @@ inputs:
     default: "true"
     type: string
 
+  upload_build:
+    required: false
+    description: "Upload build to github artifact"
+    default: "false"
+    type: string
+
+  build_directory:
+    required: false
+    description: "Set build directory"
+    default: "."
+    type: string
+
   using_cdn:
     required: false
     description: "Setup cdn for static assets"
@@ -208,6 +220,13 @@ runs:
         package: ${{ inputs.package }}
         using_cdn: ${{ inputs.using_cdn }}
         cdn_keep_latest_version: ${{ inputs.cdn_keep_latest_version }}
+
+    - name: Upload build to github artifact
+      if: "${{ inputs.upload_build == 'true' }}"
+      uses: actions/upload-artifact@v4
+      with:
+        name: build-output
+        path: ${{ inputs.build_directory }}
 
     - name: Build and push image static
       if: "${{ inputs.web_static == 'true' }}"

--- a/frontend/deploy/cfpages/action.yaml
+++ b/frontend/deploy/cfpages/action.yaml
@@ -22,6 +22,12 @@ inputs:
     description: "Set production branch"
     type: string
 
+  download_build:
+    required: false
+    description: "Download build from github artifact"
+    default: "false"
+    type: string
+
   build_directory:
     required: true
     description: "Set build directory"
@@ -43,13 +49,6 @@ inputs:
     default: "."
     type: string
 
-  # unused input, next will be remove
-  project_domain_zone:
-    required: false
-    description: "Set project domain zone"
-    default: ""
-    type: string
-
   project_custom_domain:
     required: false
     description: "Set project custom domain"
@@ -59,6 +58,13 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Download build from github artifact
+      if: "${{ inputs.download_build == 'true' }}"
+      uses: actions/download-artifact@v4
+      with:
+        name: build-output
+        path: ${{ inputs.build_directory }}
+
     - name: Deploy
       id: deploy
       uses: kitabisa/cloudflare-pages-action@v2


### PR DESCRIPTION
## What does this PR do?
- feat: add optional step for upload/download static build from github artifact
- fix: remove unused input `project_domain_zone` from cfpages deploy