### PR TITLE
fix(pr-check): prevent bash syntax errors by passing pr strings through env

### DIFF
--- a/sdet/tools/pr-check/action.yaml
+++ b/sdet/tools/pr-check/action.yaml
@@ -110,8 +110,10 @@ runs:
     - name: Check branch pattern
       id: check-branch
       shell: bash
+      env:
+        HEAD_REF: ${{ github.head_ref }}
       run: |
-        if [[ ${{ github.head_ref }} =~ ^.+?(([A-Za-z]+)-)?[0-9]+.*$ ]]; then
+        if [[ "$HEAD_REF" =~ ^.+?(([A-Za-z]+)-)?[0-9]+.*$ ]]; then
           echo "match=true" >> $GITHUB_OUTPUT
         else
           echo "match=false" >> $GITHUB_OUTPUT
@@ -120,15 +122,18 @@ runs:
     - name: Check PR body when contains JIRA ticket or Github Issue
       id: check-pr-body
       shell: bash
+      env:
+        PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        PR_BODY: ${{ github.event.pull_request.body }}
       run: |
-        headbranch='${{ github.event.pull_request.head.ref }}'
+        headbranch="$PR_HEAD_REF"
         ticket=$(echo "$headbranch" | grep -Eo '([A-Za-z]+-[0-9]{1,5})|^[^\/]+\/[0-9]{1,5}' | grep -Eo '([A-Za-z]+-[0-9]{1,5})|[0-9]{1,5}')
 
         if [[ -z "$ticket" ]]; then
           ticket=$(echo "$headbranch" | grep -Eo '/[0-9]+-' | grep -Eo '[0-9]+')
         fi
 
-        body='${{ github.event.pull_request.body }}'
+        body="$PR_BODY"
         if [[ "$body" == *"$ticket"* ]]; then
           echo "contains_ticket=true" >> $GITHUB_OUTPUT
         else
@@ -138,8 +143,13 @@ runs:
     - name: Check PR body and title for JIRA/Github ticket
       id: check-pr-updated
       shell: bash
+      env:
+        PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        PR_BODY: ${{ github.event.pull_request.body }}
+        PR_TITLE: ${{ github.event.pull_request.title }}
+        JIRA_BASE_URL: ${{ inputs.jira_base_url }}
       run: |
-        headbranch="${{ github.event.pull_request.head.ref }}"
+        headbranch="$PR_HEAD_REF"
 
         if [[ "$headbranch" =~ \/([A-Za-z]+)-([0-9]+) ]]; then
           TYPE="JIRA"
@@ -156,8 +166,8 @@ runs:
           exit 0
         fi
 
-        body=$(printf "%q" "${{ github.event.pull_request.body }}")
-        title=$(printf "%q" "${{ github.event.pull_request.title }}")
+        body="$PR_BODY"
+        title="$PR_TITLE"
 
         echo "Detected Type: $TYPE"
         echo "Detected Ticket: $TICKET"
@@ -165,7 +175,7 @@ runs:
         echo "ticket_id=$TICKET" >> $GITHUB_OUTPUT
 
         if [[ "$TYPE" == "JIRA" ]]; then
-          if grep -q "${{ inputs.jira_base_url }}/$TICKET" <<< "$body"; then
+          if grep -q "$JIRA_BASE_URL/$TICKET" <<< "$body"; then
             echo "body_updated=true" >> $GITHUB_OUTPUT
           else
             echo "body_updated=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## What does this PR do?
_Place what this pull request changes and anything affected. If your PR block or require another PR, also need to mention here_
- prevent bash syntax errors by passing pr strings through env

## Why are we doing this? Any context or related work?
_You may put your link or another here_

## Where should a reviewer start?
_optional -- if your changes affected so much files, it is encouraged to give helper for reviewer_

## Screenshots
_optional -- You may put the database, sequence or any diagram needed_
<img width="1470" height="731" alt="image" src="https://github.com/user-attachments/assets/8b5b1618-1ea2-4d3f-bd58-e56f8a22bfc3" />
<img width="1470" height="731" alt="image" src="https://github.com/user-attachments/assets/66669acb-cf50-4a4f-a421-f78909af1939" />

## Manual testing steps?
_Steps to do tests. including all possible that can hape_

## Config changes
_optional -- If there's config changes, put it here_

## Deployment instructions
_optional -- Better to put it if there's some 'special case' for deployment_
