### PR TITLE
fix(terragrunt): migrate to terragrunt run command syntax

### DIFF
--- a/infra/deploy/terragrunt/action.yaml
+++ b/infra/deploy/terragrunt/action.yaml
@@ -1,63 +1,52 @@
 name: "Terragrunt"
 description: "Runs Terragrunt Plan & Apply"
-
 inputs:
   path:
     required: true
     description: "Terragrunt path"
     type: string
-
   git_user:
     required: true
     description: "Git login user"
     type: string
-
   git_token:
     required: true
     description: "Git token access"
     type: string
-
   workload_identity_provider:
     required: true
     description: "Workload identity pool"
     type: string
-
   service_account:
     required: true
     description: "SA used in workload identity pool"
     type: string
-
 runs:
-  using: "composite"
+  using: composite
   steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-
-    - name: Configure Git for private modules
+    - name: checkout
+      uses: actions/checkout@v6
+    - name: configure git for private modules
       shell: bash
       run: git config --global url."https://${{ inputs.git_user }}:${{ inputs.git_token }}@github.com".insteadOf "https://github.com"
-
-    - name: Authenticate to Google Cloud with Workload Identity
+    - name: authenticate to google cloud with workload identity
       uses: google-github-actions/auth@v3
       with:
         workload_identity_provider: ${{ inputs.workload_identity_provider }}
         service_account: ${{ inputs.service_account }}
-
-    - name: Terragrunt Validation
+    - name: terragrunt validation
       shell: bash
       run: |
         cd ${{ inputs.path }}
-        terragrunt run-all validate --terragrunt-non-interactive
-
-    - name: Terragrunt Plan
+        terragrunt run --all validate --non-interactive
+    - name: terragrunt plan
       id: plan
       if: github.event_name == 'pull_request'
       shell: bash
       run: |
         cd ${{ inputs.path }}
-        terragrunt run-all plan --terragrunt-non-interactive -no-color > /tmp/stdout-plan.log
-
-    - name: Update Pull Request
+        terragrunt run --all plan --non-interactive --no-color > /tmp/stdout-plan.log
+    - name: update pull request
       uses: actions/github-script@v7.0.1
       if: github.event_name == 'pull_request'
       with:
@@ -67,13 +56,11 @@ runs:
           const stdout = execSync('cat /tmp/stdout-plan.log');
           const output = `
           <details>
-          <summary>Show Plan - ${{ inputs.path }}</summary>
-
+          <summary>show plan - ${{ inputs.path }}</summary>
 
           \`\`\`
           ${stdout}
           \`\`\`
-
 
           </details>
           `;
@@ -82,13 +69,11 @@ runs:
             issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
-            body: output
-          })
-
-    - name: Terragrunt Apply
+            body:
+    - name: terragrunt apply
       id: apply
       if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'release'
       shell: bash
       run: |
         cd ${{ inputs.path }}
-        terragrunt run-all apply --terragrunt-non-interactive
+        terragrunt run --all apply --non-interactive


### PR DESCRIPTION
## What

Migrate the Terragrunt composite action to use the new `terragrunt run` command syntax, replacing the deprecated `run-all` subcommand.

## Why

The `run-all` subcommand is deprecated in Terragrunt. The new syntax uses `terragrunt run --all` instead. This change ensures compatibility with newer Terragrunt versions.

## How

- Replaced `terragrunt run-all` with `terragrunt run --all` for validate, plan, and apply commands
- Changed `--terragrunt-non-interactive` flag to `--non-interactive`
- Updated checkout action from v4 to v6

## Changes

- Updated `infra/deploy/terragrunt/action.yaml`:
  - Updated `actions/checkout` from v4 to v6
  - Migrated terragrunt commands to new `run` syntax
  - Updated CLI flags to non-terragrunt-prefixed versions

<details>
<summary>Commits</summary>

- fix(terragrunt): migrate to terragrunt run command syntax (15c5354)

</details>

## Testing

Verify that the action works correctly in a test workflow using the new command syntax.

## Notes

This is a breaking change for users still on older Terragrunt versions that require `run-all`.