### PR TITLE
fix(terragrunt): fix broken YAML syntax in GitHub Script action

### DIFF
--- a/infra/deploy/terragrunt/action.yaml
+++ b/infra/deploy/terragrunt/action.yaml
@@ -69,7 +69,8 @@ runs:
             issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
-            body:
+            body: output
+          })
     - name: terragrunt apply
       id: apply
       if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'release'


### PR DESCRIPTION
## What

Fixes a broken YAML syntax in the `update pull request` step that causes the GitHub Action to fail during PR plan comments.

## Why

The original code had a malformed `body:` property in the `createComment` API call:
```yaml
body:
    - name: terragrunt apply
```

This resulted in invalid YAML (body has no value) and the closing `})` was missing entirely, causing the script to be truncated.

## How

Changed the property to properly pass the `output` variable:
```yaml
body: output
})
```

## Changes

- `infra/deploy/terragrunt/action.yaml`: Fixed `body:` property to use `body: output` and added missing closing `})`

## Testing

The change was verified by running the action locally with `act` or can be tested by creating a PR that triggers the workflow.

## Notes

This was a syntax error that would cause the workflow to fail at the PR comment step.