### PR TITLE
fix(unit_test_v2): restore deleted new_code_coverage.go referenced by action.yaml

### DIFF
--- a/backend/unit_test_v2/calc_new_code_coverage/new_code_coverage.go
+++ b/backend/unit_test_v2/calc_new_code_coverage/new_code_coverage.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+func main() {
+	if len(os.Args) < 3 {
+		fmt.Println("Usage: go run main.go <diff-file> <coverage-file>")
+		return
+	}
+
+	diffFile := os.Args[1]
+	coverageFile := os.Args[2]
+	pathScanned := os.Args[3]
+
+	// Parse the diff file to get changed files
+	changedFiles, err := parseNewFiles(diffFile)
+	if err != nil {
+		fmt.Printf("Error processing diff file: %v\n", err)
+		return
+	}
+
+	// Get coverage data using go tool cover
+	fileCoverages, err := getCoverageData(coverageFile, changedFiles, pathScanned)
+	if err != nil {
+		fmt.Printf("Error processing coverage file: %v\n", err)
+		return
+	}
+	// Check if changed files exist in coverage data and print their coverage
+	var fileCoverageResult string
+	var fileCoverageBelowThreshold string
+	fileCoverageResult += "\n"
+	fileCoverageBelowThreshold += "\n"
+	belowCoverageFlag := false
+	for file, coverage := range fileCoverages {
+		if coverage < 80 {
+			fileCoverageBelowThreshold += fmt.Sprintf("File: %s, Coverage: %.2f%%\n", file, coverage)
+			belowCoverageFlag = true
+		} else {
+			fileCoverageResult += fmt.Sprintf("File: %s, Coverage: %.2f%%\n", file, coverage)
+		}
+	}
+
+	fmt.Printf("Coverage accepted %v\n", fileCoverageResult)
+
+	if belowCoverageFlag {
+		fmt.Printf("Coverage below threshold: %v\n", fileCoverageBelowThreshold)
+	}
+}
+
+func parseNewFiles(filename string) (map[string]bool, error) {
+	file, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	newFiles := make(map[string]bool)
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "+++ b/") {
+			filePath := strings.TrimPrefix(line, "+++ b/")
+			newFiles[filePath] = true
+		} else if strings.HasPrefix(line, "--- a/") {
+			filePath := strings.TrimPrefix(line, "--- a/")
+			delete(newFiles, filePath) // Remove if it's not a new file
+		}
+	}
+
+	return newFiles, scanner.Err()
+}
+
+func getCoverageData(coverageFile string, changedFiles map[string]bool, validTestFolder string) (fileCoverages map[string]float64, err error) {
+	cmd := exec.Command("go", "tool", "cover", "-func", coverageFile)
+	output, err := cmd.Output()
+	if err != nil {
+		return
+	}
+
+	fileCoverages = make(map[string]float64)
+	scanner := bufio.NewScanner(strings.NewReader(string(output)))
+	for scanner.Scan() {
+		line := scanner.Text()
+		for file := range changedFiles {
+			cleanFile := strings.TrimSpace(file)
+			if strings.Contains(line, cleanFile) {
+				// Compile a regular expression to match one or more consecutive tabs
+				re := regexp.MustCompile(`\t+`)
+
+				// Replace all occurrences of multiple tabs with a single tab
+				strArr := re.ReplaceAllString(line, "\t")
+				strArrResult := strings.Split(strArr, "\t")
+				coveragePercent := strings.TrimSuffix(strArrResult[2], "%")
+
+				// Check if the file validTestFolder contains "internal/" and coverage is 0
+				if strings.Contains(strArrResult[0], validTestFolder) {
+					floatVal, _ := strconv.ParseFloat(coveragePercent, 64)
+					fileCoverages[fmt.Sprintf("%s %s", file, strArrResult[1])] = floatVal
+				}
+
+			}
+		}
+	}
+
+	return
+}


### PR DESCRIPTION
## Summary

The `backend/unit_test_v2/action.yaml` references `${{ github.action_path }}/calc_new_code_coverage/new_code_coverage.go` in its "Run coverage analysis" step, but this file was deleted in commit `f9d55729` while the action YAML was not updated.

This causes all workflows using `kitabisa/composite-actions/backend/unit_test_v2@v2` (or any v2 tag) to fail with:
```
stat .../calc_new_code_coverage/new_code_coverage.go: no such file or directory
```

## Fix

Restored the file from the last known good commit (`2ec3f1a`) before it was deleted.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the deleted coverage helper referenced by the unit test v2 composite action so CI workflows run successfully again. Unblocks any workflow using `kitabisa/composite-actions/backend/unit_test_v2@v2`.

- **Bug Fixes**
  - Restored `backend/unit_test_v2/calc_new_code_coverage/new_code_coverage.go` referenced by `backend/unit_test_v2/action.yaml`.
  - Fixes failures that errored with “no such file or directory” when running the “Run coverage analysis” step.

<sup>Written for commit a8e8c6bfe9a5f8d896fbc89b99c976052f2c3da0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kitabisa/composite-actions/pull/427?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

